### PR TITLE
Updating github workflow to remove build action on main push

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -4,8 +4,6 @@
 name: Maven Package
 
 on:
- push:
-   branches: [main]
  pull_request:
    branches: [main]
  release:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.sengar.api</groupId>
   <artifactId>magnus</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
   
   <name>magnus-api</name>
   <url>https://maven.pkg.github.com/uday707/magnus</url>
@@ -31,7 +31,7 @@
   <distributionManagement>
    <repository>
      <id>github</id>
-     <name>GitHub OWNER Apache Maven Packages</name>
+     <name>GitHub uday707 Apache Maven Packages</name>
      <url>https://maven.pkg.github.com/uday707/magnus</url>
    </repository>
   </distributionManagement>


### PR DESCRIPTION
Updating github workflow template for maven package build action to remove main branch push step to ignore build failure earlier due to build failure on pull request on main branch.